### PR TITLE
Need help on using `graphviz` package with this action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Compile LaTeX document with graphviz
         uses: ./
         with:
-          root_file: graphviz_test.tex
+          root_file: graphviz.tex
           working_directory: test/
           args: "-xelatex -pdf -shell-escape"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,14 @@ jobs:
           working_directory: test/
           extra_system_packages: python3-pygments
           args: "-pdf -latexoption=-shell-escape -latexoption=-file-line-error -latexoption=-interaction=nonstopmode"
+      
+      - name: Compile LaTeX document with graphviz
+        uses: ./
+        with:
+          root_file: graphviz_test.tex
+          working_directory: test/
+          args: "-xelatex -pdf -shell-escape"
+
       - name: Check pdf files
         run: |
           set -e
@@ -46,3 +54,13 @@ jobs:
           file test/math.pdf | grep -q ' PDF '
           file test/biblatex.pdf | grep -q ' PDF '
           file test/minted.pdf | grep -q ' PDF '
+          file test/graphviz_test.pdf | grep -q ' PDF '
+
+      - name: Deploy to check generated pdf files online
+        uses: docker://peaceiris/gh-pages:v2.3.1
+        env:
+          ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+          PUBLISH_BRANCH: gh-pages
+          PUBLISH_DIR: ./test
+        with:
+          emptyCommits: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
           file test/math.pdf | grep -q ' PDF '
           file test/biblatex.pdf | grep -q ' PDF '
           file test/minted.pdf | grep -q ' PDF '
-          file test/graphviz_test.pdf | grep -q ' PDF '
+          file test/graphviz.pdf | grep -q ' PDF '
 
       - name: Deploy to check generated pdf files online
         uses: docker://peaceiris/gh-pages:v2.3.1

--- a/test/graphviz.tex
+++ b/test/graphviz.tex
@@ -1,0 +1,12 @@
+\documentclass{article}
+
+ \usepackage[pdf]{graphviz}
+
+ \begin{document}
+\digraph[scale=0.5]{xabcd}{rankdir=TB;
+    x -> a [label="a.com"]
+    x -> b [label="b.com"]
+    x -> c [label="c.com"]
+    x -> d [label="d.com"]
+}
+\end{document}


### PR DESCRIPTION
Hello, could you please check the code diff here to help investigate why the generated pdf has errors while I use `graphviz` package? 

I've tested on my local windows machine with TexLive2019 installed with command `latexmk -shell-escape <root_file>`, it works as expected.

## Actual Result:
https://github.com/Jeff-Tian/latex-action/blob/gh-pages/graphviz.pdf
![image](https://user-images.githubusercontent.com/3367820/65939900-b87e0680-e459-11e9-86bf-71e11f17921f.png)

## Expected Result:
![image](https://user-images.githubusercontent.com/3367820/65939910-bcaa2400-e459-11e9-878f-a190f5245cd5.png)

Thanks a lot!