### PR TITLE
changed .tex to .aux for bibtex root_file in one of the examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ jobs:
       - name: bibtex main
         uses: dante-ev/latex-action@latest
         with:
-          root_file: main.tex
+          root_file: main.aux
           compiler: bibtex
           args: 
       - name: pdflatex main


### PR DESCRIPTION
Fixed a typo in one of the examples which pointed bibtex at the .tex file instead of the .aux file. 