### PR TITLE
Add hint on rsync

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,12 @@ Here is an example that rebuilds uses the cache at most once a day. The files to
           key: ${{ runner.os }}-${{ steps.get-date.outputs.date }}
 ```
 
+## Where to find my PDF?
+
+Please use an appropriate GitHub action.
+One option is [upload-artifact](https://github.com/actions/upload-artifact), which collects the build artifacts and stores them into a GitHub space.
+Another option is to use rsync via [action-rsyncer](https://github.com/Pendect/action-rsyncer).
+
 ## Available versions
 
 * `@latest` points to the latest release of [DANTE e.V.'s docker-texlive](https://github.com/dante-ev/docker-texlive)


### PR DESCRIPTION
Fixes https://github.com/dante-ev/latex-action/issues/12 with a small FAQ. I would not like to duplicate much information available in the net. Maybe, the references are enough for users to get an idea how to retreive the PDF.

@UweZiegenhagen Would these pointers be enough? Should I maybe point to https://github.com/dante-ev/docker-texlive/blob/07fb9eaf1db72676c9ad50ac68c75dbed05e4edc/.github/workflows/check-build.yml#L88?

