### PR TITLE
Support add offline font packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ This actions runs on docker using a [maximal TeXLive environment](https://hub.do
 
     The extra packages to be installed by [`apt-get`](https://en.wikipedia.org/wiki/APT_(Package_Manager)) separated by space.
 
+* `extra_font_packages`
+
+    The extra fonts such as some chinese fonts, please package them as a ZIP format.
+    ```yaml
+    with:
+      extra_font_packages: fonts # means fonts.zip
+    ```
+
 ## Examples
 
 ### Build `main.tex` using `latexmk`

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,8 @@ inputs:
     default: "-pdf -latexoption=-file-line-error -latexoption=-interaction=nonstopmode"
   extra_system_packages:
     description: Install extra packages by apt-get
+  extra_font_packages:
+    description: Install fonts packaged in zip format
 runs:
   using: docker
   image: Dockerfile
@@ -24,6 +26,7 @@ runs:
     - ${{ inputs.compiler }}
     - ${{ inputs.args }}
     - ${{ inputs.extra_system_packages }}
+    - ${{ inputs.extra_font_packages }}
 branding:
   icon: book
   color: blue

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,6 +7,7 @@ working_directory="$2"
 compiler="$3"
 args="$4"
 extra_system_packages="$5"
+extra_font_packages="$6"
 
 if [ -n "$extra_system_packages" ]; then
   apt-get update
@@ -18,6 +19,13 @@ fi
 
 if [ -n "$working_directory" ]; then
   cd "$working_directory"
+fi
+
+if [ -n "$extra_font_packages" ]; then
+  unzip "$extra_font_packages.zip" && \
+  mv "$extra_font_packages" /usr/share/fonts/extra_fonts/ && \
+  fc-cache -fv && \
+  fc-list :lang=zh-cn | sort
 fi
 
 "$compiler" $args "$root_file"


### PR DESCRIPTION
Some fonts are protected by copyright and cannot be download by `apt-get`, So I add an extra parameter `extra_font_packages` to allow users fonts uploaded as a ZIP package.

```yaml
    with:
      extra_font_packages: fonts # means fonts.zip
```